### PR TITLE
Fix test_ch_funcs fossil of the double_up_as_factory keyword bug

### DIFF
--- a/meshed/tests/test_ch_funcs.py
+++ b/meshed/tests/test_ch_funcs.py
@@ -1,13 +1,45 @@
+"""Tests for ``meshed.dag.ch_funcs`` -- changing the functions of existing func nodes.
+
+Besides the behaviour of ``ch_funcs`` itself, this module pins how ``ch_funcs`` may be
+*called*: it is built with ``i2.double_up_as_factory``, so it must decorate when given
+func nodes and only make a factory when not given any -- whether the func nodes are
+passed positionally or by keyword.
+"""
+
+from functools import partial
+from typing import NamedTuple
+
 import meshed as ms
 import pytest
 
 import meshed.base
 import meshed.util
-from meshed.dag import ch_funcs, _validate_func_mapping
+from meshed.dag import DAG, ch_funcs, _validate_func_mapping
 from meshed.tests.objects_for_testing import f, g
 from meshed.base import compare_signatures
-from i2 import Sig
-from typing import NamedTuple
+from i2 import Sig, double_up_as_factory
+
+
+def _wrapped_by_keyword_is_supported() -> bool:
+    """Whether the installed ``i2`` accepts a decorator's wrapped object by keyword.
+
+    Before `i2mint/i2#82 <https://github.com/i2mint/i2/pull/82>`_,
+    ``double_up_as_factory`` decided between "decorate this" and "make a factory" by
+    looking only at the first *positional* argument.  A wrapped object passed by
+    keyword therefore landed in ``**kwargs`` and the decorator silently returned a
+    ``functools.partial`` factory instead of the decorated object.
+    """
+
+    @double_up_as_factory
+    def probe(obj=None, *, unused=None):
+        return obj
+
+    return probe(obj=int) is int
+
+
+#: Whether ``ch_funcs(func_nodes=...)`` decorates (True) or wrongly returns a factory
+#: (False).  Depends on the installed ``i2`` -- see ``_wrapped_by_keyword_is_supported``.
+I2_SUPPORTS_WRAPPED_BY_KEYWORD = _wrapped_by_keyword_is_supported()
 
 
 @pytest.fixture
@@ -25,18 +57,45 @@ def example_func_mapping():
 
 
 def test_ch_funcs_no_change(example_func_nodes):
+    """Mapping every func node to the function it already has changes nothing."""
     funcs = [f, g]
     nodes = list(example_func_nodes)
     names = [node.name for node in nodes]
 
     dummy_mapping = dict(zip(names, funcs))
 
-    new_dag = ch_funcs(
-        func_nodes=nodes,
-        func_mapping=dummy_mapping,
-    )
-    new_nodes = new_dag().func_nodes
-    assert nodes == new_nodes
+    new_dag = ch_funcs(nodes, func_mapping=dummy_mapping)
+
+    assert isinstance(new_dag, DAG)
+    assert nodes == new_dag.func_nodes
+
+
+@pytest.mark.skipif(
+    not I2_SUPPORTS_WRAPPED_BY_KEYWORD,
+    reason=(
+        "installed i2 predates i2mint/i2#82, so a double_up_as_factory decorator "
+        "given its wrapped object by keyword wrongly returns a factory"
+    ),
+)
+def test_ch_funcs_takes_func_nodes_by_keyword(example_func_nodes):
+    """``ch_funcs(func_nodes=...)`` must decorate, not return a factory.
+
+    Regression pin for `i2mint/i2#82 <https://github.com/i2mint/i2/pull/82>`_: passing
+    the func nodes by keyword must mean exactly what passing them positionally means.
+    Before that fix it returned a ``functools.partial``, and call sites papered over it
+    with a trailing ``()`` -- which this test exists to stop coming back.
+    """
+    funcs = [f, g]
+    nodes = list(example_func_nodes)
+    dummy_mapping = dict(zip([node.name for node in nodes], funcs))
+
+    new_dag = ch_funcs(func_nodes=nodes, func_mapping=dummy_mapping)
+
+    assert not isinstance(new_dag, partial), "ch_funcs wrongly returned a factory"
+    assert isinstance(new_dag, DAG)
+    assert nodes == new_dag.func_nodes
+    # ...and it agrees with the positional form
+    assert new_dag.func_nodes == ch_funcs(nodes, func_mapping=dummy_mapping).func_nodes
 
 
 class FlagWithMessage(NamedTuple):


### PR DESCRIPTION
## Land this BEFORE (or together with) i2mint/i2#82

i2mint/i2#82 fixes `double_up_as_factory` so that a decorator given its wrapped object
**by keyword** decorates instead of silently returning a `functools.partial` factory.

`meshed.dag.ch_funcs` is built with `double_up_as_factory`, and one meshed test was
written against the *broken* behaviour. That test goes **pass -> fail** the moment i2#82
lands. This PR removes the fossil, so it should land first (or at the same time).

It is written to be safe to merge **now**, before i2#82 ships — see "Ordering" below.

## The fossil

`ch_funcs`'s first parameter is `func_nodes`. Before i2#82:

```python
ch_funcs(func_nodes=nodes, func_mapping=mapping)   # -> functools.partial  (wrong)
ch_funcs(nodes, func_mapping=mapping)              # -> DAG                (right)
```

`test_ch_funcs_no_change` used the keyword form and then added a trailing `()` to turn
the unexpected factory into the DAG it actually wanted:

```python
new_dag = ch_funcs(func_nodes=nodes, func_mapping=dummy_mapping)
new_nodes = new_dag().func_nodes   # the () only made sense because of the bug
```

After i2#82, `ch_funcs(func_nodes=...)` returns the DAG directly, so that trailing `()`
*calls the DAG*, which raises:

```
TypeError: missing a required argument: 'a'
```

Verified A/B against a local i2 checkout: `meshed/tests/test_ch_funcs.py` gives
`3 passed` with i2 master and `1 failed, 2 passed` with the i2#82 branch, deterministically.

## The fix

- `test_ch_funcs_no_change` now passes the func nodes **positionally** and reads
  `new_dag.func_nodes` directly. That is what the test always meant to assert
  ("an identity mapping changes nothing"), and it behaves identically on old and new i2,
  so this test keeps covering its intent regardless of which i2 is installed.
- New `test_ch_funcs_takes_func_nodes_by_keyword` pins that `ch_funcs(func_nodes=...)`
  returns a `DAG` and **not** a `partial`, and that it agrees with the positional form —
  so the fossil cannot silently come back.
- Added the missing module docstring.

## Ordering / why this is safe to merge before i2#82

The new pin asserts behaviour that only the fixed i2 has. Rather than pin an i2 version
that does not exist yet, it **feature-detects** (`_wrapped_by_keyword_is_supported()`
builds a throwaway `double_up_as_factory` decorator and checks it). So:

| installed i2 | pin |
|---|---|
| current release (pre-#82) | skipped, with a reason naming i2#82 |
| with i2#82 | runs and enforces |

The pin is not vacuous: with the guard temporarily removed and pre-#82 i2 installed it
fails with `AssertionError: ch_funcs wrongly returned a factory`.

## Test results

meshed is **already red on master** — 3 pre-existing doctest failures unrelated to this
change (`meshed/dag.py`, `meshed/makers.py`, `meshed/scrap/cached_dag.py`). Those are
untouched here. Full suite (`pytest --doctest-modules`):

| i2 | meshed | result |
|---|---|---|
| master | before this PR | 3 failed, 157 passed, 1 skipped |
| i2#82 branch | before this PR | **4 failed**, 156 passed, 1 skipped  <- the regression |
| master | **this PR** | 3 failed, 157 passed, 2 skipped (pin skipped) |
| i2#82 branch | **this PR** | 3 failed, **158 passed**, 1 skipped (pin runs) |

Same 3 pre-existing failures in every case: the baseline is not worsened, and the
regression is gone.

## Ecosystem survey

I searched the whole local package ecosystem for other call sites of this shape — passing
the wrapped object by keyword to a `double_up_as_factory`-built decorator and then calling
the result — both statically (every such decorator in i2, meshed, front, larder, py2http,
plunk, wip_qh) and dynamically (a temporary probe in `double_up_as_factory` logging every
call that takes the new code path, run across all 46 i2 dependents' suites).

**This test was the only one in executed code.** A re-review of the survey turned up a second occurrence of the same fossil in `meshed/scrap/notebook.ipynb` — a 2023 scratch notebook whose saved output shows the buggy `functools.partial` directly. That one is dead code (`scrap/` is in this repo's CI `paths-to-ignore`, and no plugin collects notebooks), so it changes no test result; it is left untouched rather than edited, because rewriting its source without re-running it would desynchronise the cells from their stored outputs. Details are in the i2#82 thread.

https://claude.ai/code/session_01Kug7UUbVeCQgruvNXUq63c
